### PR TITLE
Fix pause resume recording

### DIFF
--- a/sam-app/lambda_functions/sfExecuteTranscriptionStateMachine.py
+++ b/sam-app/lambda_functions/sfExecuteTranscriptionStateMachine.py
@@ -35,8 +35,6 @@ import logging
 logger = logging.getLogger()
 logger.setLevel(logging.getLevelName(os.environ["LOGGING_LEVEL"]))
 
-client = boto3.client('lambda')
-
 
 def process_record(record):
     #for record in records:
@@ -174,6 +172,7 @@ def createACContactChannelAnalyticsSalesforceObject(contactId, recordingPath):
         logger.info('calling: %s, contactId=%s' % (arn, contactId))
 
         try:
+            client = boto3.client('lambda')
             response = client.invoke(
                 FunctionName=arn,
                 InvocationType='RequestResponse',

--- a/sam-app/lambda_functions/sfInvokeAPI.py
+++ b/sam-app/lambda_functions/sfInvokeAPI.py
@@ -36,15 +36,21 @@ def removekey(d, key):
     return r
 
 def lambda_handler(event, context):
-  logger.info("event: %s" % json.dumps(event))
+  sf_operation = str(event['Details']['Parameters']['sf_operation'])
+  content_type = str(event['Details']['Parameters'].get('ContentType', ''))
+  parameters = dict(event['Details']['Parameters'])
 
   sf = Salesforce()
   sf.sign_in()
 
-  sf_operation = str(event['Details']['Parameters']['sf_operation'])
-  parameters = dict(event['Details']['Parameters'])
+  if content_type == "audio/wav":
+    logger.info("event: CallRecording. ParentId: %s" % str(event['Details']['Parameters']['ParentId']))
+  else:
+    logger.info("event: %s" % json.dumps(event))
+
   del parameters['sf_operation']
   event['Details']['Parameters'] = parameters
+
 
   if(sf_operation == "lookup"):
     resp = lookup(sf=sf, **event['Details']['Parameters'])

--- a/sam-app/lambda_functions/template.yaml
+++ b/sam-app/lambda_functions/template.yaml
@@ -183,6 +183,7 @@ Conditions:
   PostcallCTRImportEnabledCondition: !Equals [!Ref PostcallCTRImportEnabled, true]
   HistoricalReportingImportEnabledCondition: !Equals [!Ref HistoricalReportingImportEnabled, true]
   RealtimeReportingImportEnabledCondition: !Equals [!Ref RealtimeReportingImportEnabled, true]
+  InvokeMuteCallRecordingLambdaEnabledCondition: !Equals [!Ref InvokeMuteCallRecordingLambdaEnabled, true]
 
   CTREventSourceMappingCondition:
     !Or
@@ -492,6 +493,17 @@ Resources:
               Fn::GetAtt: sfInvokeAPI.Arn
           Version: '2012-10-17'
         PolicyName: sfExecuteTranscriptionStateMachineSfInvokeAPIPolicy
+      - Fn::If:
+        - InvokeMuteCallRecordingLambdaEnabledCondition
+        - PolicyDocument:
+            Statement:
+            - Action:
+              - lambda:InvokeFunction
+              Effect: Allow
+              Resource:
+                Ref: InvokeMuteCallRecordingLambdaARN
+            Version: '2012-10-17'
+          PolicyName: sfExecuteTranscriptionStateMachineMuteCallRecordingPolicy
 
   sfCTRTriggerRole:
     Type: AWS::IAM::Role

--- a/sam-app/lambda_functions/template.yaml
+++ b/sam-app/lambda_functions/template.yaml
@@ -164,7 +164,18 @@ Parameters:
     AllowedValues:
     - true
     - false
-
+  InvokeMuteCallRecordingLambdaEnabled:
+    Default: 'true'
+    Description: Enable or disable muting call recording before pushing to Salesforce
+    Type: String
+    AllowedPattern: ^(true|false)$
+    AllowedValues:
+      - true
+      - false
+  InvokeMuteCallRecordingLambdaARN:
+    Default: ''
+    Description: ARN of the lambda to perform the call recording muting
+    Type: String
 
 Conditions:
   PostcallRecordingImportEnabledCondition: !Equals [!Ref PostcallRecordingImportEnabled, true ]
@@ -813,7 +824,8 @@ Resources:
       Handler: sfExecuteTranscriptionStateMachine.lambda_handler
       Role:
         Fn::GetAtt: sfExecuteTranscriptionStateMachineRole.Arn
-      Timeout: 120
+      Timeout: 840
+      memorySize: 1024
       Environment:
         Variables:
           MEDIA_FORMAT: wav
@@ -829,6 +841,26 @@ Resources:
             Fn::GetAtt: sfInvokeAPI.Arn
           SF_ADAPTER_NAMESPACE:
             Ref: SalesforceAdapterNamespace
+          SF_HOST:
+            Ref: SalesforceHost
+          SF_PRODUCTION:
+            Ref: SalesforceProduction
+          SF_CONSUMER_KEY:
+            Ref: SalesforceConsumerKey
+          SF_CONSUMER_SECRET:
+            Ref: SalesforceConsumerSecret
+          SF_USERNAME:
+            Ref: SalesforceUsername
+          SF_PASSWORD:
+            Ref: SalesforcePassword
+          SF_ACCESS_TOKEN:
+            Ref: SalesforceAccessToken
+          SF_VERSION:
+            Ref: SalesforceVersion
+          INVOKE_MUTE_CALL_RECORDING_LAMBDA_ENABLED:
+              Ref: InvokeMuteCallRecordingLambdaEnabled
+          INVOKE_MUTE_CALL_RECORDING_LAMBDA_ARN:
+            Ref: InvokeMuteCallRecordingLambdaARN
 
   sfCTRTrigger:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
1. Execute Transcription calls the pause recording lambda. Controllable through env variables
2. Instead of calling the sfInvokeAPI lambda, we import sfInvokeAPI.py and call it directly to avoid hitting the lambda payload size limit
3. Remove logging the full event in case of audio/wav because it can get quite big